### PR TITLE
Updated to use configmap for the daemon config.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,26 @@
 FROM docker.io/fedora:latest
 
 RUN yum -y update && \
-	yum install -y git python3 libvirt-python3 python3-pyghmi python3-zmq python3-pbr python3-urllib3 python3-pip golang golang-github-pebbe-zmq4-devel && \
+	yum install -y git python3 libvirt-python3 python3-pyghmi python3-zmq python3-pbr python3-urllib3 python3-pip golang golang-github-pebbe-zmq4-devel pipenv && \
 	yum install -y vim && \
 	mkdir /root/git && \
 	cd /root/git && \
 	git clone https://github.com/kubevirt/client-python.git && \
 	git clone --recursive https://github.com/kubernetes-client/python.git && \
-	git clone https://github.com/colonwq/go-virtualbmc.git
-RUN yum install -y pipenv
-RUN cd /root/git/python && python setup.py install
+	git clone https://github.com/colonwq/go-virtualbmc.git && \
+	cd /root/git/python && python setup.py install
 ADD . /root/git/virtualbmc
 RUN echo "export PYTHONPATH=/root/git/virtualbmc:/root/git/python:/root/git/client-python/" > /root/vbmcd.sh
 RUN echo "cd /root/git/virtualbmc" >> /root/vbmcd.sh
 RUN echo "python3 virtualbmc/cmd/vbmcd.py --foreground" >> /root/vbmcd.sh
-
 RUN echo "printenv | sort" >> /root/vbmcd.sh
+
 RUN chmod +x /root/vbmcd.sh
-RUN mkdir /kubeconfig
-VOLUME /kubeconfig
-ENV KUBECONFIG /kubeconfig/config
+RUN mkdir -p /var/run/virtualbmc/domains
 ENV GOPATH /usr/share/gocode
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/git/go-virtualbmc
-ENTRYPOINT /root/vbmcd.sh
-
-ENV VIRTUALBMC_CONFIG /kubeconfig/virtualbmc.conf
+#ENTRYPOINT /root/vbmcd.sh
 
 RUN echo "while [ true ] ; do sleep 20; echo 'going to sleep'; done " > /root/loop.sh
 RUN chmod +x /root/loop.sh
-RUN yum install -y net-tools ipmitool
 #ENTRYPOINT /root/loop.sh 

--- a/virtbmc-operator.yaml
+++ b/virtbmc-operator.yaml
@@ -1,35 +1,4 @@
 ---
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: virtbmc-pv-volume
-  labels:
-    type: local
-spec:
-  storageClassName: virtbmc-pv
-  capacity:
-    storage: 10Gi
-  accessModes:
-    - ReadWriteOnce
-  nfs:
-    server: 10.0.0.142
-    path: "/home/kschinck/.kube-nest"
-
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: virtbmc-pv-claim
-  namespace: kubevirt
-spec:
-  storageClassName: virtbmc-pv
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 3Gi
-
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -55,15 +24,18 @@ spec:
       name: virtbmc-operator
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       volumes:
-      - name: virtbmc-pv-storage
-        persistentVolumeClaim:
-          claimName: virtbmc-pv-claim
+      - name: virtualbmc-config
+        configMap:
+          name: virtualbmc-conf
       containers:
       - command:
         - /bin/bash
         - /root/vbmcd.sh
         env:
+        - name: VIRTUALBMC_CONFIG 
+          value: /etc/virtualbmc/virtualbmc.conf
         - name: OPERATOR_IMAGE
           value: myreg.localhost:5000/myrepo/virtualbmc:latest
         - name: WATCH_NAMESPACE
@@ -73,17 +45,10 @@ spec:
         image: myreg.localhost:5000/myrepo/virtualbmc:latest
         imagePullPolicy: Always
         name: virtbmc-operator
-        ports:
-        - containerPort: 50891
-          name: vbmc
-          protocol: TCP
-        - containerPort: 6230
-          name: ipmi
-          protocol: UDP
         resources: {}
         volumeMounts:
-          - mountPath: "/kubeconfig"
-            name: virtbmc-pv-storage
+          - mountPath: /etc/virtualbmc
+            name: virtualbmc-config
       securityContext:
         runAsNonRoot: false
       serviceAccountName: kubevirt-operator

--- a/virtualbmc/manager.py
+++ b/virtualbmc/manager.py
@@ -228,8 +228,6 @@ class VirtualBMCManager(object):
             libvirt_uri, libvirt_sasl_username, libvirt_sasl_password,
             namespace, name, **kwargs):
 
-        print("namespace: ", namespace)
-        print("name: ", name)
         # check libvirt's connection and if domain exist prior to adding it
         if CONF['default']['kubevirt'] != 'true':
             utils.check_libvirt_connection_and_domain(

--- a/virtualbmc/vbmc.py
+++ b/virtualbmc/vbmc.py
@@ -41,12 +41,12 @@ def get_client(kubeconfig=None):
     Returns:
         kubevirt.DefaultApi: Instance of KubeVirt client
     """
-    if kubeconfig is None:
-        kubeconfig = os.environ.get("KUBECONFIG")
-        if kubeconfig is None:
-            kubeconfig = os.path.expanduser("~/.kube/config")
-    cl = config.kube_config._get_kube_config_loader_for_yaml_file(kubeconfig)
-    cl.load_and_set(kubevirt.configuration)
+    tokenHandle = open("/var/run/secrets/kubernetes.io/serviceaccount/token", "r")
+    tokenData = tokenHandle.read()
+    kubevirt.configuration.api_key['authorization'] = tokenData
+    kubevirt.configuration.api_key_prefix['authorization'] = 'Bearer'
+    kubevirt.configuration.host = "https://kubernetes.default.svc"
+    kubevirt.configuration.ssl_ca_cert = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 
     return kubevirt.DefaultApi()
 


### PR DESCRIPTION
The pod file was updated to remove the pv/pvc. A configmap is used
to configure the service. The runtime files are moved to
/var/run/virtualbmc/domains. This status is lost each time the pod
is restarted.